### PR TITLE
Issue 4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN go build -o /riff-entrypoint cmd/${COMPONENT}.go
 
 ###########
 
-FROM golang:1.10
+FROM debian:wheezy-slim
 
 # The following line forces the creation of a /tmp directory
 WORKDIR /tmp

--- a/samples/runningaverage/README.adoc
+++ b/samples/runningaverage/README.adoc
@@ -40,7 +40,7 @@ riff create go --input numbers --output runningaverage --artifact runningaverage
 
 === Make sure that the function is not configured for windowing
 
-Recent builds of the riff CLI configure functions with a windowing size of 1. Check `runningaverage-function.yaml` and comment out the windowing size if necessary.
+Recent builds of the riff CLI configure functions with a windowing size of 1. Check `runningaverage-link.yaml` and comment out the windowing size if necessary.
 
 ```yaml
   # windowing:


### PR DESCRIPTION
Addresses #4 .  This uses debian wheezy:slim which includes `libc` and cuts the image size to ~ 59MB. Both samples worked for me.  I got the idea from https://blog.docker.com/2016/09/docker-golang/  
`Re-using another distro’s libc` 