### PR TITLE
URL Cleanup

### DIFF
--- a/vendor/golang.org/x/net/http2/testdata/draft-ietf-httpbis-http2.xml
+++ b/vendor/golang.org/x/net/http2/testdata/draft-ietf-httpbis-http2.xml
@@ -270,7 +270,7 @@
         HTTP/2 uses the same "http" and "https" URI schemes used by HTTP/1.1. HTTP/2 shares the same
         default port numbers: 80 for "http" URIs and 443 for "https" URIs.  As a result,
         implementations processing requests for target resource URIs like <spanx
-        style="verb">http://example.org/foo</spanx> or <spanx
+        style="verb">https://example.org/foo</spanx> or <spanx
         style="verb">https://example.com/bar</spanx> are required to first discover whether the
         upstream server (the immediate peer to which the client wishes to establish a connection)
         supports HTTP/2.
@@ -4567,7 +4567,7 @@ HTTP2-Settings    = token68
       </reference>
 
       <reference anchor='HTML5'
-           target='http://www.w3.org/TR/2014/CR-html5-20140731/'>
+           target='https://www.w3.org/TR/2014/CR-html5-20140731/'>
         <front>
           <title>HTML5</title>
           <author fullname='Robin Berjon' surname='Berjon' initials='R.'/>
@@ -4581,11 +4581,11 @@ HTTP2-Settings    = token68
         <seriesInfo name='W3C Candidate Recommendation' value='CR-html5-20140731'/>
         <annotation>
           Latest version available at
-          <eref target='http://www.w3.org/TR/html5/'/>.
+          <eref target='https://www.w3.org/TR/html5/'/>.
         </annotation>
       </reference>
 
-      <reference anchor="TALKING" target="http://w2spconf.com/2011/papers/websocket.pdf">
+      <reference anchor="TALKING" target="https://w2spconf.com/2011/papers/websocket.pdf">
         <front>
           <title>
             Talking to Yourself for Fun and Profit


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://breachattack.com/resources/BREACH%20-%20SSL,%20gone%20in%2030%20seconds.pdf (404) with 1 occurrences could not be migrated:  
   ([https](https://breachattack.com/resources/BREACH%20-%20SSL,%20gone%20in%2030%20seconds.pdf) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://w2spconf.com/2011/papers/websocket.pdf (UnknownHostException) with 1 occurrences migrated to:  
  https://w2spconf.com/2011/papers/websocket.pdf ([https](https://w2spconf.com/2011/papers/websocket.pdf) result UnknownHostException).
* http://example.org/foo (404) with 1 occurrences migrated to:  
  https://example.org/foo ([https](https://example.org/foo) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.w3.org/TR/2014/CR-html5-20140731/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/2014/CR-html5-20140731/ ([https](https://www.w3.org/TR/2014/CR-html5-20140731/) result 200).
* http://www.w3.org/TR/html5/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/html5/ ([https](https://www.w3.org/TR/html5/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://a9.com/-/spec/opensearch/1.1/ with 1 occurrences
* http://purl.org/net/xml2rfc/ext with 1 occurrences
* http://www.w3.org/TR/html4/ with 2 occurrences